### PR TITLE
scalardl-java-client-sdk version update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ repositories {
 }
 
 dependencies {
-    compile group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '2.0.4'
+    compile group: 'com.scalar-labs', name: 'scalardl-java-client-sdk', version: '2.0.9'
     compile 'info.picocli:picocli:3.5.2'
     testCompile 'org.mockito:mockito-core:2.+'
     testCompile 'junit:junit:4.12'


### PR DESCRIPTION
Scalardl java client version updated to 2.0.9 for scalardb 2.2.0 support.